### PR TITLE
feat: add blog section with seo improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import CaseDetail from "./pages/CaseDetail";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
 import Book from "./pages/Book";
+import Blog from "./pages/Blog";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -28,6 +29,7 @@ const App = () => (
           <Route path="/nosotros" element={<About />} />
           <Route path="/contacto" element={<Contact />} />
           <Route path="/book" element={<Book />} />
+          <Route path="/blog" element={<Blog />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -101,6 +101,11 @@ const Footer = () => {
                 </Link>
               </li>
               <li>
+                <Link to="/blog" className="transition-colors hover:text-capasso-primary">
+                  Blog
+                </Link>
+              </li>
+              <li>
                 <Link to="/book" className="transition-colors hover:text-capasso-primary">
                   Agenda una reunión
                 </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,6 +49,7 @@ const Header = () => {
     { label: "Servicios", type: "section" as const, target: "servicios" },
     { label: "Tecnologías", type: "section" as const, target: "tecnologias" },
     { label: "Casos", type: "section" as const, target: "casos-exito" },
+    { label: "Blog", type: "route" as const, path: "/blog" },
     { label: "Nosotros", type: "route" as const, path: "/nosotros" },
     { label: "Contacto", type: "route" as const, path: "/contacto" },
   ];

--- a/src/data/blog-posts.ts
+++ b/src/data/blog-posts.ts
@@ -1,0 +1,94 @@
+export type BlogPost = {
+  slug: string;
+  title: string;
+  date: string;
+  category: string;
+  summary: string;
+  content: string[];
+  readingTime: number;
+  tags: string[];
+  serviceFocus: string;
+};
+
+export const blogPosts: BlogPost[] = [
+  {
+    slug: "pod-agil-time-to-market",
+    title: "Cómo un pod ágil acelera el time-to-market sin romper la calidad",
+    date: "2024-08-05",
+    category: "Pods ágiles",
+    summary:
+      "Te contamos cómo armar un pod ágil nearshore que entrega iteraciones productivas cada dos semanas, con visibilidad total y deuda técnica bajo control.",
+    content: [
+      "Los pods ágiles combinan PM, tech lead, diseñadores y desarrolladores senior para cubrir discovery, delivery y medición sin handoffs innecesarios. Cuando cada rol entiende métricas de negocio y se trabaja con roadmaps trimestrales visibles, el equipo sostiene un throughput predecible desde el sprint uno.",
+      "El secreto está en definir Definition of Ready y Definition of Done compartidas, sumado a tableros visibles que reflejan bloqueos en tiempo real. Con este modelo logramos reducir en 35% el ciclo de feedback con founders y stakeholders porque todos hablan el mismo lenguaje de valor entregado.",
+      "En CapassoTech desplegamos pods dedicados en menos de diez días, con herramientas de automatización y QA desde el inicio. Así evitamos cuellos de botella, logramos releases semanales sin sobresaltos y liberamos a tu equipo in-house para enfocarse en estrategia y revenue.",
+    ],
+    readingTime: 6,
+    tags: ["outsourcing", "pods ágiles", "time-to-market"],
+    serviceFocus: "Outsourcing de equipos",
+  },
+  {
+    slug: "migracion-cloud-sin-downtime",
+    title: "Checklist para migrar tu producto a la nube sin downtime ni sorpresas de costos",
+    date: "2024-07-22",
+    category: "DevOps & Cloud",
+    summary:
+      "Esta guía resume los hitos críticos para planificar una migración cloud exitosa: assessment, arquitectura híbrida, pruebas de carga y monitoreo FinOps desde el día cero.",
+    content: [
+      "Antes de migrar, evaluamos dependencias, SLAs y la criticidad de cada módulo. Con esa foto diseñamos un roadmap de oleadas priorizando componentes que ya soportan contenedores y automatizando pipelines de despliegue.",
+      "Ejecutamos ambientes espejo para validar performance con tráfico real y feature flags para activar gradualmente a usuarios. Esta estrategia nos permitió sostener 99,98% de disponibilidad en migraciones de plataformas transaccionales.",
+      "El monitoreo FinOps complementa el proceso: dashboards de consumo, alertas de sobrecostos y políticas de apagado automático nos ayudaron a reducir en promedio 27% el gasto mensual post migración.",
+    ],
+    readingTime: 7,
+    tags: ["cloud", "devops", "finops"],
+    serviceFocus: "Mantenimiento proactivo",
+  },
+  {
+    slug: "automatizaciones-ia-roi-90-dias",
+    title: "3 automatizaciones con IA que generan ROI en 90 días",
+    date: "2024-06-10",
+    category: "Inteligencia Artificial",
+    summary:
+      "Analizamos casos reales donde la inteligencia artificial libera horas operativas y aumenta conversiones rápidamente: scoring de leads, soporte asistido y generación de documentos.",
+    content: [
+      "Arrancamos identificando procesos con alto volumen y reglas claras. El scoring de leads con modelos supervisados nos permitió priorizar oportunidades comerciales, incrementando 22% la tasa de cierre al enfocar SDRs en prospects listos para comprar.",
+      "Para soporte implementamos asistentes que se entrenan con la base de conocimiento existente y entregan respuestas sugeridas en vivo. Resultado: reducción del tiempo promedio de respuesta a la mitad sin perder tono humano.",
+      "La tercera automatización apunta a generar documentación técnica y legales repetitivas. Con templates y validaciones humanas finales, los equipos liberan hasta 15 horas semanales que vuelven a la innovación del producto.",
+    ],
+    readingTime: 5,
+    tags: ["automatización", "ia aplicada", "productividad"],
+    serviceFocus: "Consultoría & IA",
+  },
+  {
+    slug: "escalar-mvp-producto-enterprise",
+    title: "Cómo escalar un MVP a producto enterprise sin frenar la operación",
+    date: "2024-05-02",
+    category: "Desarrollo a medida",
+    summary:
+      "Compartimos el blueprint que usamos para llevar MVPs con tracción a plataformas enterprise: modularización, observabilidad y governance de releases.",
+    content: [
+      "El primer paso es auditar la arquitectura actual para detectar cuellos de botella en performance y seguridad. Diseñamos un plan de refactor incremental donde cada iteración deja valor visible y no bloquea la operación en producción.",
+      "Implementamos observabilidad con métricas de negocio y logs centralizados. Así identificamos problemas antes de que impacten a usuarios enterprise y podemos accionar mejoras basadas en datos.",
+      "Finalmente definimos governance de releases: branch strategy, feature toggles y ambientes automatizados. El equipo logra releases predecibles y auditables, requisito clave para vender a corporaciones.",
+    ],
+    readingTime: 8,
+    tags: ["escalabilidad", "arquitectura", "governance"],
+    serviceFocus: "Desarrollo a medida",
+  },
+  {
+    slug: "metricas-producto-digital",
+    title: "Las métricas que miramos para acelerar un producto digital B2B",
+    date: "2024-04-15",
+    category: "Estrategia de producto",
+    summary:
+      "Un framework práctico para alinear producto, tecnología y negocio midiendo adopción, eficiencia operativa y expansión de cuentas.",
+    content: [
+      "Partimos de objetivos trimestrales claros y los descomponemos en métricas accionables: activation rate, cycle time y expansión neta. Cada squad tiene ownership sobre uno de estos indicadores.",
+      "Reforzamos la analítica con dashboards compartidos y rituales quincenales de insights. Esto habilita decisiones rápidas, como priorizar features que aumentan la adopción o automatizaciones que liberan tiempo del equipo de customer success.",
+      "El resultado es un backlog alineado al negocio y una comunicación transparente con inversores y clientes enterprise, que ven cómo cada release mueve la aguja.",
+    ],
+    readingTime: 6,
+    tags: ["métricas", "b2b", "product management"],
+    serviceFocus: "Consultoría & IA",
+  },
+];

--- a/src/hooks/usePageSEO.ts
+++ b/src/hooks/usePageSEO.ts
@@ -1,0 +1,184 @@
+import { useEffect } from "react";
+
+type StructuredData = Record<string, unknown>;
+
+interface SEOOptions {
+  title: string;
+  description: string;
+  canonical?: string;
+  image?: string;
+  ogType?: string;
+  structuredData?: StructuredData | StructuredData[];
+}
+
+const ensureMeta = (key: string, attribute: "name" | "property") => {
+  let element = document.head.querySelector(`meta[${attribute}="${key}"]`) as HTMLMetaElement | null;
+  const created = !element;
+
+  if (!element) {
+    element = document.createElement("meta");
+    element.setAttribute(attribute, key);
+    document.head.appendChild(element);
+  }
+
+  return { element, created };
+};
+
+const ensureCanonical = () => {
+  let element = document.head.querySelector('link[rel="canonical"]') as HTMLLinkElement | null;
+  const created = !element;
+
+  if (!element) {
+    element = document.createElement("link");
+    element.setAttribute("rel", "canonical");
+    document.head.appendChild(element);
+  }
+
+  return { element, created };
+};
+
+export const usePageSEO = ({
+  title,
+  description,
+  canonical,
+  image,
+  ogType = "website",
+  structuredData,
+}: SEOOptions) => {
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const previousTitle = document.title;
+    document.title = title;
+
+    const descriptionMeta = ensureMeta("description", "name");
+    const previousDescription = descriptionMeta.element.getAttribute("content");
+    descriptionMeta.element.setAttribute("content", description);
+
+    const ogTitleMeta = ensureMeta("og:title", "property");
+    const previousOgTitle = ogTitleMeta.element.getAttribute("content");
+    ogTitleMeta.element.setAttribute("content", title);
+
+    const ogDescriptionMeta = ensureMeta("og:description", "property");
+    const previousOgDescription = ogDescriptionMeta.element.getAttribute("content");
+    ogDescriptionMeta.element.setAttribute("content", description);
+
+    const ogTypeMeta = ensureMeta("og:type", "property");
+    const previousOgType = ogTypeMeta.element.getAttribute("content");
+    ogTypeMeta.element.setAttribute("content", ogType);
+
+    const twitterTitleMeta = ensureMeta("twitter:title", "name");
+    const previousTwitterTitle = twitterTitleMeta.element.getAttribute("content");
+    twitterTitleMeta.element.setAttribute("content", title);
+
+    const twitterDescriptionMeta = ensureMeta("twitter:description", "name");
+    const previousTwitterDescription = twitterDescriptionMeta.element.getAttribute("content");
+    twitterDescriptionMeta.element.setAttribute("content", description);
+
+    let previousOgImage: string | null = null;
+    let previousTwitterImage: string | null = null;
+    let ogImageMetaCreated = false;
+    let twitterImageMetaCreated = false;
+
+    if (image) {
+      const ogImageMeta = ensureMeta("og:image", "property");
+      previousOgImage = ogImageMeta.element.getAttribute("content");
+      ogImageMeta.element.setAttribute("content", image);
+      ogImageMetaCreated = ogImageMeta.created;
+
+      const twitterImageMeta = ensureMeta("twitter:image", "name");
+      previousTwitterImage = twitterImageMeta.element.getAttribute("content");
+      twitterImageMeta.element.setAttribute("content", image);
+      twitterImageMetaCreated = twitterImageMeta.created;
+    }
+
+    const canonicalLink = ensureCanonical();
+    const previousCanonical = canonicalLink.element.getAttribute("href");
+    if (canonical) {
+      canonicalLink.element.setAttribute("href", canonical);
+    }
+
+    const structuredDataArray = structuredData
+      ? Array.isArray(structuredData)
+        ? structuredData
+        : [structuredData]
+      : [];
+
+    const schemaScripts = structuredDataArray.map((schema) => {
+      const script = document.createElement("script");
+      script.type = "application/ld+json";
+      script.textContent = JSON.stringify(schema);
+      document.head.appendChild(script);
+      return script;
+    });
+
+    return () => {
+      document.title = previousTitle;
+
+      if (descriptionMeta.created) {
+        descriptionMeta.element.remove();
+      } else if (previousDescription !== null) {
+        descriptionMeta.element.setAttribute("content", previousDescription);
+      }
+
+      if (ogTitleMeta.created) {
+        ogTitleMeta.element.remove();
+      } else if (previousOgTitle !== null) {
+        ogTitleMeta.element.setAttribute("content", previousOgTitle);
+      }
+
+      if (ogDescriptionMeta.created) {
+        ogDescriptionMeta.element.remove();
+      } else if (previousOgDescription !== null) {
+        ogDescriptionMeta.element.setAttribute("content", previousOgDescription);
+      }
+
+      if (ogTypeMeta.created) {
+        ogTypeMeta.element.remove();
+      } else if (previousOgType !== null) {
+        ogTypeMeta.element.setAttribute("content", previousOgType);
+      }
+
+      if (twitterTitleMeta.created) {
+        twitterTitleMeta.element.remove();
+      } else if (previousTwitterTitle !== null) {
+        twitterTitleMeta.element.setAttribute("content", previousTwitterTitle);
+      }
+
+      if (twitterDescriptionMeta.created) {
+        twitterDescriptionMeta.element.remove();
+      } else if (previousTwitterDescription !== null) {
+        twitterDescriptionMeta.element.setAttribute("content", previousTwitterDescription);
+      }
+
+      if (image) {
+        const ogImageMeta = ensureMeta("og:image", "property");
+        const twitterImageMeta = ensureMeta("twitter:image", "name");
+
+        if (ogImageMetaCreated) {
+          ogImageMeta.element.remove();
+        } else if (previousOgImage !== null) {
+          ogImageMeta.element.setAttribute("content", previousOgImage);
+        }
+
+        if (twitterImageMetaCreated) {
+          twitterImageMeta.element.remove();
+        } else if (previousTwitterImage !== null) {
+          twitterImageMeta.element.setAttribute("content", previousTwitterImage);
+        }
+      }
+
+      if (canonical) {
+        if (canonicalLink.created) {
+          canonicalLink.element.remove();
+        } else if (previousCanonical !== null) {
+          canonicalLink.element.setAttribute("href", previousCanonical);
+        }
+      }
+
+      schemaScripts.forEach((script) => {
+        script.remove();
+      });
+    };
+  }, [title, description, canonical, image, ogType, structuredData]);
+};

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,0 +1,334 @@
+import { useMemo, useState } from "react";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import StickyCTA from "@/components/StickyCTA";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { blogPosts } from "@/data/blog-posts";
+import { usePageSEO } from "@/hooks/usePageSEO";
+import { trackEvent } from "@/lib/analytics";
+
+const calendlyUrl = "https://calendly.com/capassoelias/15min";
+const whatsappUrl = "https://wa.me/5493435332132?text=Hola%20CapassoTech%2C%20quiero%20asesor%C3%ADa";
+
+const Blog = () => {
+  const [categoryFilter, setCategoryFilter] = useState("todas");
+  const [serviceFilter, setServiceFilter] = useState("todos");
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const blogStructuredData = useMemo(
+    () => [
+      {
+        "@context": "https://schema.org",
+        "@type": "Blog",
+        name: "Blog de CapassoTech",
+        description:
+          "Consejos accionables sobre desarrollo de software a medida, pods ágiles e IA aplicada para compañías en crecimiento.",
+        url: "https://capassotech.com/blog",
+        inLanguage: "es",
+        publisher: {
+          "@type": "Organization",
+          name: "CapassoTech",
+          url: "https://capassotech.com/",
+          logo: {
+            "@type": "ImageObject",
+            url: "https://capassotech.com/logo-light.png",
+          },
+        },
+        blogPost: blogPosts.map((post) => ({
+          "@type": "BlogPosting",
+          headline: post.title,
+          datePublished: post.date,
+          dateModified: post.date,
+          description: post.summary,
+          url: `https://capassotech.com/blog#${post.slug}`,
+          inLanguage: "es",
+          keywords: post.tags.join(", "),
+          author: {
+            "@type": "Organization",
+            name: "CapassoTech",
+          },
+        })),
+      },
+    ],
+    []
+  );
+
+  usePageSEO({
+    title: "Blog de CapassoTech — Desarrollo de software, pods ágiles e IA aplicada",
+    description:
+      "Aprendé con nuestros especialistas cómo escalar productos digitales con pods ágiles, migraciones cloud e inteligencia artificial enfocada en ROI.",
+    canonical: "https://capassotech.com/blog",
+    image: "https://capassotech.com/og-image.jpg",
+    ogType: "blog",
+    structuredData: blogStructuredData,
+  });
+
+  const sortedPosts = useMemo(
+    () =>
+      [...blogPosts].sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+      ),
+    []
+  );
+
+  const categories = useMemo(() => {
+    const unique = new Set(sortedPosts.map((post) => post.category));
+    return ["todas", ...unique];
+  }, [sortedPosts]);
+
+  const serviceLines = useMemo(() => {
+    const unique = new Set(sortedPosts.map((post) => post.serviceFocus));
+    return ["todos", ...unique];
+  }, [sortedPosts]);
+
+  const filteredPosts = useMemo(() => {
+    const normalizedSearch = searchQuery.trim().toLowerCase();
+
+    return sortedPosts.filter((post) => {
+      const matchesCategory =
+        categoryFilter === "todas" || post.category === categoryFilter;
+      const matchesService =
+        serviceFilter === "todos" || post.serviceFocus === serviceFilter;
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        [post.title, post.summary, post.serviceFocus, post.category, post.tags.join(" "), post.content.join(" ")]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedSearch);
+
+      return matchesCategory && matchesService && matchesSearch;
+    });
+  }, [categoryFilter, serviceFilter, sortedPosts, searchQuery]);
+
+  const featuredPost = sortedPosts[0];
+
+  const handleCalendly = (origin: string) => {
+    trackEvent("calendly_click", { location: origin });
+    window.open(calendlyUrl, "_blank", "noopener,noreferrer");
+  };
+
+  const handleWhatsApp = (origin: string) => {
+    trackEvent("whatsapp_click", { location: origin });
+    window.open(whatsappUrl, "_blank", "noopener,noreferrer");
+  };
+
+  const resetFilters = () => {
+    setCategoryFilter("todas");
+    setServiceFilter("todos");
+    setSearchQuery("");
+  };
+
+  return (
+    <div className="min-h-screen bg-capasso-dark text-capasso-light">
+      <Header />
+      <main>
+        <section className="bg-capasso-secondary/20 pt-32 pb-16">
+          <div className="container mx-auto px-4">
+            <div className="grid gap-10 lg:grid-cols-[2fr_1fr] lg:items-center">
+              <div>
+                <p className="text-sm uppercase tracking-wide text-capasso-primary/70">Blog CapassoTech</p>
+                <h1 className="mt-3 text-4xl font-bold text-white md:text-5xl">
+                  Estrategias para construir productos que mueven la aguja
+                </h1>
+                <p className="mt-5 text-lg text-capasso-light/80">
+                  Publicamos guías y aprendizajes reales de proyectos en Latinoamérica y Estados Unidos. Son artículos pensados para founders, CTOs y líderes de producto que necesitan velocidad sin perder calidad.
+                </p>
+                <div className="mt-8 flex flex-wrap gap-4">
+                  <Button onClick={() => handleCalendly("blog_hero")} className="btn-primary px-8 py-4 text-lg">
+                    Planificar proyecto
+                  </Button>
+                  <Button onClick={() => handleWhatsApp("blog_hero")} className="btn-secondary px-8 py-4 text-lg">
+                    Escribir por WhatsApp
+                  </Button>
+                </div>
+              </div>
+              {featuredPost && (
+                <article className="rounded-2xl border border-capasso-gray/60 bg-capasso-secondary/60 p-6 shadow-lg shadow-black/10">
+                  <span className="inline-flex items-center rounded-full bg-capasso-primary/20 px-3 py-1 text-sm font-medium text-capasso-primary">
+                    Nuevo
+                  </span>
+                  <h2 className="mt-4 text-2xl font-semibold text-white">{featuredPost.title}</h2>
+                  <p className="mt-3 text-capasso-light/80">{featuredPost.summary}</p>
+                  <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-capasso-light/60">
+                    <span>{format(new Date(featuredPost.date), "d 'de' MMMM yyyy", { locale: es })}</span>
+                    <span>• {featuredPost.readingTime} min de lectura</span>
+                    <span>• {featuredPost.category}</span>
+                  </div>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {featuredPost.tags.map((tag) => (
+                      <Badge
+                        key={`${featuredPost.slug}-${tag}`}
+                        variant="secondary"
+                        className="border border-capasso-gray/40 bg-capasso-dark text-capasso-light"
+                      >
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </article>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="bg-capasso-dark py-16">
+          <div className="container mx-auto px-4">
+            <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+              <div className="max-w-2xl">
+                <h2 className="text-3xl font-bold text-white md:text-4xl">Explorá los artículos</h2>
+                <p className="mt-3 text-capasso-light/70">
+                  Filtrá por categoría, línea de servicio o buscá palabras clave para encontrar ideas listas para implementar en tu equipo.
+                </p>
+              </div>
+              <div className="grid w-full gap-4 md:w-auto md:grid-cols-3">
+                <label className="flex flex-col text-sm text-capasso-light/70">
+                  <span className="mb-2 font-semibold text-capasso-light">Buscar</span>
+                  <Input
+                    value={searchQuery}
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    placeholder="Ej: migración cloud"
+                    className="border-capasso-gray bg-capasso-secondary/70 text-capasso-light placeholder:text-capasso-light/50"
+                  />
+                </label>
+                <label className="flex flex-col text-sm text-capasso-light/70">
+                  <span className="mb-2 font-semibold text-capasso-light">Categoría</span>
+                  <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+                    <SelectTrigger className="border-capasso-gray bg-capasso-secondary/70 text-capasso-light">
+                      <SelectValue placeholder="Todas las categorías" />
+                    </SelectTrigger>
+                    <SelectContent className="border border-capasso-gray bg-capasso-dark text-capasso-light">
+                      {categories.map((category) => (
+                        <SelectItem key={category} value={category}>
+                          {category === "todas" ? "Todas las categorías" : category}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+                <label className="flex flex-col text-sm text-capasso-light/70">
+                  <span className="mb-2 font-semibold text-capasso-light">Servicio</span>
+                  <Select value={serviceFilter} onValueChange={setServiceFilter}>
+                    <SelectTrigger className="border-capasso-gray bg-capasso-secondary/70 text-capasso-light">
+                      <SelectValue placeholder="Todas las líneas" />
+                    </SelectTrigger>
+                    <SelectContent className="border border-capasso-gray bg-capasso-dark text-capasso-light">
+                      {serviceLines.map((service) => (
+                        <SelectItem key={service} value={service}>
+                          {service === "todos" ? "Todos los servicios" : service}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+              </div>
+            </div>
+
+            <div className="mt-12 grid gap-8 md:grid-cols-2">
+              {filteredPosts.map((post) => (
+                <article
+                  key={post.slug}
+                  id={post.slug}
+                  className="flex h-full flex-col justify-between rounded-2xl border border-capasso-gray/60 bg-capasso-secondary/70 p-8 shadow-lg shadow-black/10 transition-transform duration-300 hover:-translate-y-1 hover:shadow-capasso-primary/10"
+                >
+                  <div>
+                    <div className="flex flex-wrap items-center gap-3 text-sm text-capasso-light/70">
+                      <span className="rounded-full bg-capasso-primary/20 px-3 py-1 text-capasso-primary">{post.category}</span>
+                      <span>{format(new Date(post.date), "d 'de' MMMM yyyy", { locale: es })}</span>
+                      <span>• {post.readingTime} min de lectura</span>
+                    </div>
+                    <h3 className="mt-4 text-2xl font-semibold text-white">{post.title}</h3>
+                    <p className="mt-3 text-base text-capasso-light/80">{post.summary}</p>
+                    <div className="mt-4 space-y-4 text-sm leading-relaxed text-capasso-light/75">
+                      {post.content.map((paragraph, index) => (
+                        <p key={`${post.slug}-${index}`}>{paragraph}</p>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="mt-6 flex flex-wrap items-center gap-3">
+                    {post.tags.map((tag) => (
+                      <Badge
+                        key={`${post.slug}-${tag}`}
+                        variant="secondary"
+                        className="border border-capasso-gray/40 bg-capasso-dark text-capasso-light"
+                      >
+                        {tag}
+                      </Badge>
+                    ))}
+                    <Button
+                      onClick={() => handleCalendly(`blog_post_${post.slug}`)}
+                      className="btn-primary ml-auto px-6 py-3"
+                    >
+                      Conversar proyecto
+                    </Button>
+                  </div>
+                </article>
+              ))}
+            </div>
+
+            {filteredPosts.length === 0 && (
+              <div className="mt-12 rounded-2xl border border-dashed border-capasso-gray/60 bg-capasso-secondary/50 p-12 text-center">
+                <h3 className="text-2xl font-semibold text-white">No encontramos artículos para esa búsqueda.</h3>
+                <p className="mt-3 text-capasso-light/70">
+                  Probá con otra palabra clave o escribinos y armamos un plan a medida para tu proyecto digital.
+                </p>
+                <div className="mt-6 flex flex-wrap justify-center gap-4">
+                  <Button onClick={resetFilters} className="btn-secondary px-6 py-3">
+                    Limpiar filtros
+                  </Button>
+                  <Button onClick={() => handleWhatsApp("blog_empty_state")} className="btn-primary px-6 py-3">
+                    Hablar con un especialista
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="bg-capasso-secondary/30 py-20">
+          <div className="container mx-auto grid gap-12 px-4 lg:grid-cols-2">
+            <div>
+              <h2 className="text-3xl font-bold text-white md:text-4xl">Llevemos estas ideas a tu roadmap</h2>
+              <p className="mt-4 text-capasso-light/70">
+                Contanos en qué etapa está tu producto y diseñamos una propuesta con hitos, métricas y equipo asignado en menos de 48 horas.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-4">
+                <Button onClick={() => handleCalendly("blog_cta")} className="btn-primary px-8 py-4 text-lg">
+                  Agendar 15 min
+                </Button>
+                <Button onClick={() => handleWhatsApp("blog_cta")} className="btn-secondary px-8 py-4 text-lg">
+                  Escribir por WhatsApp
+                </Button>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-capasso-gray/60 bg-capasso-secondary/70 p-6 shadow-lg shadow-black/10">
+              <h3 className="text-2xl font-semibold text-white">¿Qué te llevás en la primera reunión?</h3>
+              <ul className="mt-4 space-y-3 text-capasso-light/75">
+                <li className="flex items-start gap-3">
+                  <span className="mt-1 inline-block h-2 w-2 rounded-full bg-capasso-primary" />
+                  <span>Diagnóstico express del estado de tu producto o proceso.</span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-1 inline-block h-2 w-2 rounded-full bg-capasso-primary" />
+                  <span>Ideas priorizadas según impacto en revenue, eficiencia o experiencia de usuario.</span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-1 inline-block h-2 w-2 rounded-full bg-capasso-primary" />
+                  <span>Roadmap sugerido con pods ágiles, automatizaciones o consultoría según tu objetivo.</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+      <StickyCTA />
+    </div>
+  );
+};
+
+export default Blog;


### PR DESCRIPTION
## Summary
- add a dedicated blog page fed by static post data with search, category and service filters ordered by recency
- expose the blog section through routing, header and footer navigation entries
- introduce a reusable SEO hook to manage dynamic meta tags and structured data for the blog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb57f863bc833085a93bf97e376ef2