### PR TITLE
Add page-level SEO metadata across marketing pages

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -3,6 +3,7 @@ import ProcessSection from "@/components/ProcessSection";
 import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
+import { usePageSEO } from "@/hooks/usePageSEO";
 
 const calendlyUrl = "https://calendly.com/capassoelias/15min";
 const whatsappUrl = "https://wa.me/5493435332132?text=Hola%20CapassoTech%2C%20quiero%20asesor%C3%ADa";
@@ -27,6 +28,15 @@ const values = [
 ];
 
 const About = () => {
+  usePageSEO({
+    title: "Nosotros — CapassoTech: equipo ágil de producto y tecnología",
+    description:
+      "Conocé a CapassoTech, un equipo senior que combina producto, diseño y desarrollo para lanzar y escalar software con métricas claras.",
+    canonical: "https://capassotech.com/nosotros",
+    image: "https://capassotech.com/og-image.jpg",
+    ogType: "website",
+  });
+
   window.scrollTo(0, 0);
 
   const openCalendly = (origin) => {

--- a/src/pages/Book.jsx
+++ b/src/pages/Book.jsx
@@ -1,29 +1,41 @@
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import { usePageSEO } from "@/hooks/usePageSEO";
 
-const Book = () => (
-  <div className="min-h-screen bg-capasso-dark text-capasso-light">
-    <Header />
-    <main className="pt-32 pb-20">
-      <div className="container mx-auto px-4 text-center">
-        <div className="mx-auto max-w-3xl">
-          <p className="text-sm uppercase tracking-wide text-capasso-primary/70">Agenda</p>
-          <h1 className="mt-3 text-4xl font-bold text-white md:text-5xl">Reservá 15 minutos con nuestro equipo</h1>
-          <p className="mt-4 text-lg text-capasso-light/80">
-            Elegí el horario que prefieras para conversar sobre tu proyecto y definir próximos pasos.
-          </p>
+const Book = () => {
+  usePageSEO({
+    title: "Agenda CapassoTech — Reservá una reunión de 15 minutos",
+    description:
+      "Elegí un horario en la agenda de CapassoTech para conversar sobre tu proyecto de software, automatización o IA.",
+    canonical: "https://capassotech.com/book",
+    image: "https://capassotech.com/og-image.jpg",
+    ogType: "website",
+  });
+
+  return (
+    <div className="min-h-screen bg-capasso-dark text-capasso-light">
+      <Header />
+      <main className="pt-32 pb-20">
+        <div className="container mx-auto px-4 text-center">
+          <div className="mx-auto max-w-3xl">
+            <p className="text-sm uppercase tracking-wide text-capasso-primary/70">Agenda</p>
+            <h1 className="mt-3 text-4xl font-bold text-white md:text-5xl">Reservá 15 minutos con nuestro equipo</h1>
+            <p className="mt-4 text-lg text-capasso-light/80">
+              Elegí el horario que prefieras para conversar sobre tu proyecto y definir próximos pasos.
+            </p>
+          </div>
+          <div className="mt-12 flex justify-center">
+            <iframe
+              title="Agenda CapassoTech"
+              src="https://calendly.com/capassoelias/15min?hide_landing_page_details=1&hide_gdpr_banner=1"
+              className="h-[900px] w-full max-w-4xl rounded-2xl border border-capasso-gray/60 bg-white"
+            />
+          </div>
         </div>
-        <div className="mt-12 flex justify-center">
-          <iframe
-            title="Agenda CapassoTech"
-            src="https://calendly.com/capassoelias/15min?hide_landing_page_details=1&hide_gdpr_banner=1"
-            className="h-[900px] w-full max-w-4xl rounded-2xl border border-capasso-gray/60 bg-white"
-          />
-        </div>
-      </div>
-    </main>
-    <Footer />
-  </div>
-);
+      </main>
+      <Footer />
+    </div>
+  );
+};
 
 export default Book;

--- a/src/pages/CaseDetail.jsx
+++ b/src/pages/CaseDetail.jsx
@@ -5,6 +5,7 @@ import Footer from "@/components/Footer";
 import cases from "@/data/cases.json";
 import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
+import { usePageSEO } from "@/hooks/usePageSEO";
 
 const calendlyUrl = "https://calendly.com/capassoelias/15min";
 const whatsappUrl = "https://wa.me/5493435332132?text=Hola%20CapassoTech%2C%20quiero%20asesor%C3%ADa";
@@ -13,6 +14,22 @@ const CaseDetail = () => {
   const { caseId } = useParams();
 
   const caseStudy = useMemo(() => cases.find((item) => item.slug === caseId), [caseId]);
+
+  const seoTitle = caseStudy ? `${caseStudy.title} — Caso de éxito CapassoTech` : "Caso de éxito — CapassoTech";
+  const seoDescription = caseStudy
+    ? caseStudy.description
+    : "Casos de éxito de CapassoTech en desarrollo de software, automatización e IA.";
+  const canonicalUrl = caseStudy
+    ? `https://capassotech.com/casos/${caseStudy.slug}`
+    : "https://capassotech.com/casos";
+
+  usePageSEO({
+    title: seoTitle,
+    description: seoDescription,
+    canonical: canonicalUrl,
+    image: "https://capassotech.com/og-image.jpg",
+    ogType: "article",
+  });
 
   if (!caseStudy) {
     return <Navigate to="/casos" replace />;

--- a/src/pages/Cases.jsx
+++ b/src/pages/Cases.jsx
@@ -4,11 +4,21 @@ import Footer from "@/components/Footer";
 import cases from "@/data/cases.json";
 import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
+import { usePageSEO } from "@/hooks/usePageSEO";
 
 const calendlyUrl = "https://calendly.com/capassoelias/15min";
 const whatsappUrl = "https://wa.me/5493435332132?text=Hola%20CapassoTech%2C%20quiero%20asesor%C3%ADa";
 
 const Cases = () => {
+  usePageSEO({
+    title: "Casos de éxito CapassoTech — Software y automatización con impacto",
+    description:
+      "Explorá proyectos reales de desarrollo, integraciones e IA donde CapassoTech mejoró métricas clave en empresas de LATAM y Estados Unidos.",
+    canonical: "https://capassotech.com/casos",
+    image: "https://capassotech.com/og-image.jpg",
+    ogType: "website",
+  });
+
   const openCalendly = (origin) => {
     trackEvent("calendly_click", { location: origin });
     window.open(calendlyUrl, "_blank", "noopener,noreferrer");

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -3,11 +3,21 @@ import Footer from "@/components/Footer";
 import ContactForm from "@/components/ContactForm";
 import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
+import { usePageSEO } from "@/hooks/usePageSEO";
 
 const calendlyUrl = "https://calendly.com/capassoelias/15min";
 const whatsappUrl = "https://wa.me/5493435332132?text=Hola%20CapassoTech%2C%20quiero%20asesor%C3%ADa";
 
 const Contact = () => {
+  usePageSEO({
+    title: "Contacto CapassoTech — Agendá una discovery call en 15 minutos",
+    description:
+      "Escribinos o reservá una reunión rápida para hablar sobre tu proyecto de software, automatización o IA con el equipo de CapassoTech.",
+    canonical: "https://capassotech.com/contacto",
+    image: "https://capassotech.com/og-image.jpg",
+    ogType: "website",
+  });
+
   const openCalendly = (origin) => {
     trackEvent("calendly_click", { location: origin });
     window.open(calendlyUrl, "_blank", "noopener,noreferrer");

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -11,6 +11,7 @@ import ContactForm from "@/components/ContactForm";
 import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
+import { usePageSEO } from "@/hooks/usePageSEO";
 
 const calendlyUrl = "https://calendly.com/capassoelias/15min";
 const whatsappUrl = "https://wa.me/5493435332132?text=Hola%20CapassoTech%2C%20quiero%20asesor%C3%ADa";
@@ -41,6 +42,15 @@ const differentiators = [
 const Home = () => {
   const location = useLocation();
   const navigate = useNavigate();
+
+  usePageSEO({
+    title: "CapassoTech — Software a medida, pods ágiles e IA enfocada en ROI",
+    description:
+      "Equipo de producto y tecnología que diseña y escala software, automatizaciones e IA con métricas claras desde el primer sprint.",
+    canonical: "https://capassotech.com/",
+    image: "https://capassotech.com/og-image.jpg",
+    ogType: "website",
+  });
 
   useEffect(() => {
     const targetId = location.state && typeof location.state === "object" ? location.state.scrollTo : undefined;

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -4,6 +4,7 @@ import Footer from "@/components/Footer";
 import ContactForm from "@/components/ContactForm";
 import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
+import { usePageSEO } from "@/hooks/usePageSEO";
 
 const calendlyUrl = "https://calendly.com/capassoelias/15min";
 const whatsappUrl = "https://wa.me/5493435332132?text=Hola%20CapassoTech%2C%20quiero%20asesor%C3%ADa";
@@ -72,6 +73,15 @@ const servicesDetail = [
 ];
 
 const Services = () => {
+  usePageSEO({
+    title: "Servicios CapassoTech — Desarrollo a medida, pods ágiles, consultoría e IA",
+    description:
+      "Planes modulares para construir MVPs, sumar squads ágiles, auditar arquitectura y aplicar inteligencia artificial con foco en resultados.",
+    canonical: "https://capassotech.com/servicios",
+    image: "https://capassotech.com/og-image.jpg",
+    ogType: "website",
+  });
+
   const openCalendly = (origin) => {
     trackEvent("calendly_click", { location: origin });
     window.open(calendlyUrl, "_blank", "noopener,noreferrer");

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -126,5 +127,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- integrate the `usePageSEO` hook into the main marketing pages to provide tailored titles, descriptions, canonicals and OG data
- drive case study detail metadata from the selected case so shared links stay consistent with the content
- address eslint issues by replacing empty interfaces and updating the Tailwind plugin import

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d42e0f33908330a32c6a649183cc82