### PR TITLE
Add JSON-LD structured data for services and case studies

### DIFF
--- a/src/pages/Cases.jsx
+++ b/src/pages/Cases.jsx
@@ -9,6 +9,56 @@ import { usePageSEO } from "@/hooks/usePageSEO";
 const calendlyUrl = "https://calendly.com/capassoelias/15min";
 const whatsappUrl = "https://wa.me/5493435332132?text=Hola%20CapassoTech%2C%20quiero%20asesor%C3%ADa";
 
+const baseProvider = {
+  "@type": "Organization",
+  name: "CapassoTech",
+  url: "https://capassotech.com",
+};
+
+const casesStructuredData = cases.map((caseStudy) => ({
+  "@context": "https://schema.org",
+  "@type": "CaseStudy",
+  name: caseStudy.title,
+  alternateName: caseStudy.slug,
+  description: caseStudy.description,
+  abstract: caseStudy.summary,
+  genre: caseStudy.category,
+  provider: { ...baseProvider },
+  audience: {
+    "@type": "Audience",
+    audienceType: caseStudy.category,
+  },
+  keywords: [...caseStudy.technologies, ...caseStudy.services],
+  url: `https://capassotech.com/casos/${caseStudy.slug}`,
+  inLanguage: "es",
+  creativeWorkStatus: "Published",
+  about: caseStudy.services.map((service) => ({
+    "@type": "Service",
+    name: service,
+  })),
+  mentions: caseStudy.technologies.map((tech) => ({
+    "@type": "Thing",
+    name: tech,
+  })),
+  hasPart: [
+    {
+      "@type": "CreativeWork",
+      name: "Desafíos abordados",
+      text: caseStudy.challenges.join(" • "),
+    },
+    {
+      "@type": "CreativeWork",
+      name: "Solución implementada",
+      text: caseStudy.solution.join(" • "),
+    },
+    {
+      "@type": "CreativeWork",
+      name: "Resultados destacados",
+      text: caseStudy.results.join(" • "),
+    },
+  ],
+}));
+
 const Cases = () => {
   usePageSEO({
     title: "Casos de éxito CapassoTech — Software y automatización con impacto",
@@ -17,6 +67,7 @@ const Cases = () => {
     canonical: "https://capassotech.com/casos",
     image: "https://capassotech.com/og-image.jpg",
     ogType: "website",
+    structuredData: casesStructuredData,
   });
 
   const openCalendly = (origin) => {

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -72,6 +72,49 @@ const servicesDetail = [
   },
 ];
 
+const baseProvider = {
+  "@type": "Organization",
+  name: "CapassoTech",
+  url: "https://capassotech.com",
+};
+
+const servicesStructuredData = servicesDetail.map((service) => ({
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: service.title,
+  description: service.intro,
+  serviceType: service.title,
+  provider: { ...baseProvider },
+  areaServed: {
+    "@type": "AdministrativeArea",
+    name: "Latinoamérica",
+  },
+  availableChannel: {
+    "@type": "ServiceChannel",
+    serviceUrl: "https://capassotech.com/servicios",
+  },
+  offers: {
+    "@type": "Offer",
+    availability: "https://schema.org/InStock",
+    url: "https://capassotech.com/contacto",
+    description: "Planes personalizados y squads ágiles según alcance y objetivos.",
+  },
+  hasOfferCatalog: {
+    "@type": "OfferCatalog",
+    name: `${service.title} - Qué incluye`,
+    itemListElement: service.bullets.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item,
+    })),
+  },
+  serviceOutput: service.outcomes.map((outcome) => ({
+    "@type": "Thing",
+    name: outcome,
+  })),
+  termsOfService: "https://capassotech.com/servicios",
+}));
+
 const Services = () => {
   usePageSEO({
     title: "Servicios CapassoTech — Desarrollo a medida, pods ágiles, consultoría e IA",
@@ -80,6 +123,7 @@ const Services = () => {
     canonical: "https://capassotech.com/servicios",
     image: "https://capassotech.com/og-image.jpg",
     ogType: "website",
+    structuredData: servicesStructuredData,
   });
 
   const openCalendly = (origin) => {


### PR DESCRIPTION
## Summary
- generate JSON-LD Service schemas for each offering on the services page to surface deliverables and outcomes in rich snippets
- build JSON-LD CaseStudy schemas that describe challenges, solutions, results and technologies for every case study
- connect both pages to the existing SEO hook so the structured data is injected into the document head

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d42fac4a988330b0f62c5e32ebe940