### PR TITLE
Expose anchor links for key navigation sections

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { trackEvent } from "@/lib/analytics";
 
@@ -9,13 +10,18 @@ const Footer = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const navigateOrScroll = (sectionId: string) => {
+  const handleInternalNavigation = (
+    event: MouseEvent<HTMLAnchorElement>,
+    sectionId: string,
+  ) => {
     if (location.pathname === "/") {
+      event.preventDefault();
       const section = document.getElementById(sectionId);
       if (section) {
         section.scrollIntoView({ behavior: "smooth" });
       }
     } else {
+      event.preventDefault();
       navigate("/", { state: { scrollTo: sectionId } });
     }
   };
@@ -40,24 +46,32 @@ const Footer = () => {
               Tu partner tecnológico para desarrollo a medida, pods ágiles y consultoría enfocada en resultados.
             </p>
             <div className="mt-6 flex gap-4">
-              <button
-                onClick={() => handleWhatsApp("footer")}
+              <a
+                href={whatsappUrl}
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleWhatsApp("footer");
+                }}
                 className="rounded-lg bg-capasso-secondary p-3 text-capasso-light transition-all duration-300 hover:bg-capasso-primary hover:text-white"
                 aria-label="WhatsApp"
               >
                 <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.439 9.884-9.885 9.884" />
                 </svg>
-              </button>
-              <button
-                onClick={() => handleCalendly("footer")}
+              </a>
+              <a
+                href={calendlyUrl}
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleCalendly("footer");
+                }}
                 className="rounded-lg bg-capasso-secondary p-3 text-capasso-light transition-all duration-300 hover:bg-capasso-primary hover:text-white"
                 aria-label="Agendar 15 minutos"
               >
                 <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10m-12 9h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v11a2 2 0 002 2z" />
                 </svg>
-              </button>
+              </a>
             </div>
           </div>
 
@@ -65,14 +79,22 @@ const Footer = () => {
             <h3 className="mb-4 text-lg font-semibold text-capasso-light">Servicios</h3>
             <ul className="space-y-2 text-capasso-light/70">
               <li>
-                <button onClick={() => navigateOrScroll("servicios")} className="transition-colors hover:text-capasso-primary">
+                <a
+                  href="/#servicios"
+                  onClick={(event) => handleInternalNavigation(event, "servicios")}
+                  className="transition-colors hover:text-capasso-primary"
+                >
                   Desarrollo a medida
-                </button>
+                </a>
               </li>
               <li>
-                <button onClick={() => navigateOrScroll("servicios")} className="transition-colors hover:text-capasso-primary">
+                <a
+                  href="/#servicios"
+                  onClick={(event) => handleInternalNavigation(event, "servicios")}
+                  className="transition-colors hover:text-capasso-primary"
+                >
                   Outsourcing de equipos
-                </button>
+                </a>
               </li>
               <li>
                 <Link to="/servicios" className="transition-colors hover:text-capasso-primary">
@@ -91,9 +113,13 @@ const Footer = () => {
             <h3 className="mb-4 text-lg font-semibold text-capasso-light">Recursos</h3>
             <ul className="space-y-2 text-capasso-light/70">
               <li>
-                <button onClick={() => navigateOrScroll("tecnologias")} className="transition-colors hover:text-capasso-primary">
+                <a
+                  href="/#tecnologias"
+                  onClick={(event) => handleInternalNavigation(event, "tecnologias")}
+                  className="transition-colors hover:text-capasso-primary"
+                >
                   Stack tecnológico
-                </button>
+                </a>
               </li>
               <li>
                 <Link to="/casos" className="transition-colors hover:text-capasso-primary">
@@ -127,9 +153,13 @@ const Footer = () => {
                 </Link>
               </li>
               <li>
-                <button onClick={() => navigateOrScroll("proceso")} className="transition-colors hover:text-capasso-primary">
+                <a
+                  href="/#proceso"
+                  onClick={(event) => handleInternalNavigation(event, "proceso")}
+                  className="transition-colors hover:text-capasso-primary"
+                >
                   Nuestro proceso
-                </button>
+                </a>
               </li>
               <li>
                 <a href="mailto:contacto@capasso.tech" className="transition-colors hover:text-capasso-primary">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -21,14 +22,19 @@ const Header = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const navigateOrScroll = (sectionId: string) => {
+  const handleInternalNavigation = (
+    event: MouseEvent<HTMLAnchorElement>,
+    sectionId: string,
+  ) => {
     if (location.pathname === "/") {
+      event.preventDefault();
       const section = document.getElementById(sectionId);
       if (section) {
         section.scrollIntoView({ behavior: "smooth" });
       }
       setIsMobileMenuOpen(false);
     } else {
+      event.preventDefault();
       navigate("/", { state: { scrollTo: sectionId } });
       setIsMobileMenuOpen(false);
     }
@@ -76,13 +82,14 @@ const Header = () => {
                 {item.label}
               </Link>
             ) : (
-              <button
+              <a
                 key={item.label}
-                onClick={() => navigateOrScroll(item.target)}
+                href={`/#${item.target}`}
+                onClick={(event) => handleInternalNavigation(event, item.target)}
                 className="hover:text-capasso-primary transition-colors"
               >
                 {item.label}
-              </button>
+              </a>
             ),
           )}
         </div>
@@ -120,9 +127,14 @@ const Header = () => {
                   {item.label}
                 </Link>
               ) : (
-                <button key={item.label} onClick={() => navigateOrScroll(item.target)} className="text-base text-left">
+                <a
+                  key={item.label}
+                  href={`/#${item.target}`}
+                  onClick={(event) => handleInternalNavigation(event, item.target)}
+                  className="text-base text-left"
+                >
                   {item.label}
-                </button>
+                </a>
               ),
             )}
             <div className="mt-4 flex flex-col gap-3">

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -6,9 +6,10 @@ const calendlyUrl = "https://calendly.com/capassoelias/15min";
 const whatsappUrl = "https://wa.me/5493435332132?text=Hola%20CapassoTech%2C%20quiero%20asesor%C3%ADa";
 
 const Hero = () => {
-  const scrollToSection = (sectionId) => {
+  const handleAnchorNavigation = (event, sectionId) => {
     const element = document.getElementById(sectionId);
     if (element) {
+      event.preventDefault();
       element.scrollIntoView({ behavior: "smooth" });
     }
   };
@@ -48,11 +49,27 @@ const Hero = () => {
           </p>
 
           <div className="mb-12 flex flex-col justify-center gap-4 sm:flex-row">
-            <Button onClick={handleCalendly} className="btn-primary px-8 py-4 text-lg">
-              Agendar 15 min
+            <Button asChild className="btn-primary px-8 py-4 text-lg">
+              <a
+                href={calendlyUrl}
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleCalendly();
+                }}
+              >
+                Agendar 15 min
+              </a>
             </Button>
-            <Button onClick={handleWhatsApp} className="btn-secondary px-8 py-4 text-lg">
-              Escribir por WhatsApp
+            <Button asChild className="btn-secondary px-8 py-4 text-lg">
+              <a
+                href={whatsappUrl}
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleWhatsApp();
+                }}
+              >
+                Escribir por WhatsApp
+              </a>
             </Button>
           </div>
 
@@ -76,12 +93,13 @@ const Hero = () => {
 
           <div className="mt-12 flex flex-col items-center gap-2 text-capasso-light/60">
             <span>Preferís ver más primero?</span>
-            <button
-              onClick={() => scrollToSection("servicios")}
+            <a
+              href="#servicios"
+              onClick={(event) => handleAnchorNavigation(event, "servicios")}
               className="text-capasso-primary transition-colors hover:text-capasso-primary/80"
             >
               Conocé nuestros servicios
-            </button>
+            </a>
           </div>
         </div>
       </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,11 +1,16 @@
 
+import type { MouseEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import { Code, Users, Zap } from 'lucide-react';
 
 const HeroSection = () => {
-  const scrollToSection = (sectionId: string) => {
+  const handleAnchorNavigation = (
+    event: MouseEvent<HTMLAnchorElement>,
+    sectionId: string,
+  ) => {
     const element = document.getElementById(sectionId);
     if (element) {
+      event.preventDefault();
       element.scrollIntoView({ behavior: 'smooth' });
     }
   };
@@ -35,17 +40,21 @@ const HeroSection = () => {
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-            <Button
-              onClick={() => scrollToSection('contacto')}
-              className="btn-primary text-lg px-8 py-4"
-            >
-              Solicitá una reunión
+            <Button asChild className="btn-primary text-lg px-8 py-4">
+              <a
+                href="#contacto"
+                onClick={(event) => handleAnchorNavigation(event, 'contacto')}
+              >
+                Solicitá una reunión
+              </a>
             </Button>
-            <Button
-              onClick={() => scrollToSection('servicios')}
-              className="btn-secondary text-lg px-8 py-4"
-            >
-              Conocé nuestros servicios
+            <Button asChild className="btn-secondary text-lg px-8 py-4">
+              <a
+                href="#servicios"
+                onClick={(event) => handleAnchorNavigation(event, 'servicios')}
+              >
+                Conocé nuestros servicios
+              </a>
             </Button>
           </div>
 


### PR DESCRIPTION
## Summary
- replace scroll buttons in the header with hash anchors that preserve smooth scrolling while allowing bots to follow navigation links
- expose hash anchors in hero CTAs and footer quick links, reusing button styling via asChild wrappers and wiring analytics handlers to anchor clicks
- update footer icons for WhatsApp and Calendly to use accessible anchor links while keeping tracking behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d433210034833081da93dbed51f01d