### PR TITLE
Link case studies with blog articles

### DIFF
--- a/src/components/CaseStudiesSection.tsx
+++ b/src/components/CaseStudiesSection.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import cases from "@/data/cases.json";
@@ -75,6 +76,16 @@ const CaseStudiesSection = () => {
                       </li>
                     ))}
                   </ul>
+                </div>
+                <div className="mt-auto flex flex-wrap items-center gap-3">
+                  {caseStudy.relatedBlogSlug && (
+                    <Button asChild className="btn-secondary px-6 py-3 text-sm">
+                      <Link to={`/blog/${caseStudy.relatedBlogSlug}`}>Leer artículo del proyecto</Link>
+                    </Button>
+                  )}
+                  <Button asChild variant="link" className="px-0 text-capasso-primary">
+                    <Link to={`/casos/${caseStudy.slug}`}>Ver caso completo →</Link>
+                  </Button>
                 </div>
               </CardContent>
             </Card>

--- a/src/data/blog-posts.ts
+++ b/src/data/blog-posts.ts
@@ -8,6 +8,7 @@ export type BlogPost = {
   readingTime: number;
   tags: string[];
   serviceFocus: string;
+  relatedCaseSlug?: string;
 };
 
 export const blogPosts: BlogPost[] = [
@@ -29,6 +30,7 @@ export const blogPosts: BlogPost[] = [
     readingTime: 6,
     tags: ["autopartes", "marketplace", "integraciones"],
     serviceFocus: "Desarrollo a medida",
+    relatedCaseSlug: "catalogo-web-autopartes",
   }
   ,
   {

--- a/src/data/cases.json
+++ b/src/data/cases.json
@@ -29,6 +29,7 @@
     "title": "Catálogo Web de Autopartes",
     "category": "Distribución",
     "summary": "Sistema de catalogación y sitio público con buscador de autopartes integrado al backend administrativo.",
+    "relatedBlogSlug": "andretich-autopartes-transformacion-digital",
     "description": "Un distribuidor regional necesitaba digitalizar su catálogo para dar soporte a vendedores y clientes finales en varios países.",
     "challenges": [
       "Actualizar miles de referencias en tiempo real",

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -182,6 +182,11 @@ const Blog = () => {
                         Leer artículo completo
                       </Link>
                     </Button>
+                    {featuredPost.relatedCaseSlug && (
+                      <Button asChild variant="link" className="mt-3 px-0 text-capasso-primary">
+                        <Link to={`/casos/${featuredPost.relatedCaseSlug}`}>Ver caso de éxito</Link>
+                      </Button>
+                    )}
                   </div>
                 </article>
               )}
@@ -254,38 +259,45 @@ const Blog = () => {
                       <span>{format(new Date(post.date), "d 'de' MMMM yyyy", { locale: es })}</span>
                       <span>• {post.readingTime} min de lectura</span>
                     </div>
-                    <h3 className="mt-4 text-2xl font-semibold text-white">{post.title}</h3>
-                    <p className="mt-3 text-base text-capasso-light/80">{post.summary}</p>
-                  </div>
-                  <div className="mt-6 flex flex-wrap items-center gap-3">
-                    {post.tags.map((tag) => (
-                      <Badge
-                        key={`${post.slug}-${tag}`}
-                        variant="secondary"
-                        className="border border-capasso-gray/40 bg-capasso-dark text-capasso-light"
-                      >
-                        {tag}
-                      </Badge>
-                    ))}
-                    <Button asChild className="btn-secondary px-6 py-3">
-                      <Link
-                        to={`/blog/${post.slug}`}
-                        onClick={() =>
-                          trackEvent("blog_post_open", { slug: post.slug })
-                        }
-                      >
-                        Leer artículo
-                      </Link>
-                    </Button>
-                    <Button
-                      onClick={() => handleCalendly(`blog_post_${post.slug}`)}
-                      className="btn-primary ml-auto px-6 py-3"
+                  <h3 className="mt-4 text-2xl font-semibold text-white">{post.title}</h3>
+                  <p className="mt-3 text-base text-capasso-light/80">{post.summary}</p>
+                </div>
+                <div className="mt-6 flex flex-wrap items-center gap-3">
+                  {post.tags.map((tag) => (
+                    <Badge
+                      key={`${post.slug}-${tag}`}
+                      variant="secondary"
+                      className="border border-capasso-gray/40 bg-capasso-dark text-capasso-light"
                     >
-                      Conversar proyecto
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+                <div className="mt-6 flex flex-wrap items-center gap-3">
+                  <Button asChild className="btn-secondary px-6 py-3">
+                    <Link
+                      to={`/blog/${post.slug}`}
+                      onClick={() =>
+                        trackEvent("blog_post_open", { slug: post.slug })
+                      }
+                    >
+                      Leer artículo
+                    </Link>
+                  </Button>
+                  {post.relatedCaseSlug && (
+                    <Button asChild variant="link" className="px-0 text-capasso-primary">
+                      <Link to={`/casos/${post.relatedCaseSlug}`}>Ver caso de éxito</Link>
                     </Button>
-                  </div>
-                </article>
-              ))}
+                  )}
+                  <Button
+                    onClick={() => handleCalendly(`blog_post_${post.slug}`)}
+                    className="btn-primary ml-auto px-6 py-3"
+                  >
+                    Conversar proyecto
+                  </Button>
+                </div>
+              </article>
+            ))}
             </div>
 
             {filteredPosts.length === 0 && (

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -8,6 +8,7 @@ import StickyCTA from "@/components/StickyCTA";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { blogPosts } from "@/data/blog-posts";
+import cases from "@/data/cases.json";
 import { usePageSEO } from "@/hooks/usePageSEO";
 import { trackEvent } from "@/lib/analytics";
 
@@ -37,6 +38,16 @@ const BlogPost = () => {
         url: canonicalUrl,
         inLanguage: "es",
         keywords: post.tags.join(", "),
+        ...(post.relatedCaseSlug
+          ? {
+              mentions: [
+                {
+                  "@type": "CaseStudy",
+                  url: `https://capassotech.com/casos/${post.relatedCaseSlug}`,
+                },
+              ],
+            }
+          : {}),
         author: {
           "@type": "Organization",
           name: "CapassoTech",
@@ -95,6 +106,9 @@ const BlogPost = () => {
   const relatedPosts = blogPosts
     .filter((entry) => entry.slug !== post.slug)
     .slice(0, 3);
+  const relatedCase = post.relatedCaseSlug
+    ? cases.find((caseStudy) => caseStudy.slug === post.relatedCaseSlug)
+    : undefined;
 
   const handleCalendly = (origin: string) => {
     trackEvent("calendly_click", { location: origin, slug: post.slug });
@@ -150,18 +164,34 @@ const BlogPost = () => {
                 </Button>
               </div>
             </div>
-            <div className="w-full max-w-xs rounded-2xl border border-capasso-gray/60 bg-capasso-secondary/60 p-6 text-sm text-capasso-light/80">
-              <p className="font-semibold uppercase tracking-wide text-capasso-primary">
-                ¿Por qué este artículo importa?
-              </p>
-              <p className="mt-3">
-                Está basado en proyectos reales donde aplicamos este enfoque. Podés usarlo como checklist para tu próximo sprint o roadmap.
-              </p>
-              <Button asChild variant="link" className="mt-4 px-0 text-capasso-primary">
-                <Link to="/blog" className="hover:underline">
-                  Volver al listado del blog
-                </Link>
-              </Button>
+            <div className="w-full max-w-xs space-y-4">
+              <div className="rounded-2xl border border-capasso-gray/60 bg-capasso-secondary/60 p-6 text-sm text-capasso-light/80">
+                <p className="font-semibold uppercase tracking-wide text-capasso-primary">
+                  ¿Por qué este artículo importa?
+                </p>
+                <p className="mt-3">
+                  Está basado en proyectos reales donde aplicamos este enfoque. Podés usarlo como checklist para tu próximo sprint o roadmap.
+                </p>
+                <Button asChild variant="link" className="mt-4 px-0 text-capasso-primary">
+                  <Link to="/blog" className="hover:underline">
+                    Volver al listado del blog
+                  </Link>
+                </Button>
+              </div>
+              {relatedCase && (
+                <div className="rounded-2xl border border-capasso-primary/30 bg-capasso-primary/10 p-6 text-sm text-capasso-light/80">
+                  <p className="font-semibold uppercase tracking-wide text-capasso-primary">
+                    Caso de éxito relacionado
+                  </p>
+                  <p className="mt-3 text-base text-white">{relatedCase.title}</p>
+                  <p className="mt-2">
+                    Conocé cómo lo implementamos paso a paso y qué métricas movimos junto al cliente.
+                  </p>
+                  <Button asChild className="btn-secondary mt-4 w-full">
+                    <Link to={`/casos/${relatedCase.slug}`}>Ver caso completo</Link>
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
         </section>

--- a/src/pages/CaseDetail.jsx
+++ b/src/pages/CaseDetail.jsx
@@ -3,6 +3,7 @@ import { Link, Navigate, useParams } from "react-router-dom";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import cases from "@/data/cases.json";
+import { blogPosts } from "@/data/blog-posts";
 import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
 import { usePageSEO } from "@/hooks/usePageSEO";
@@ -14,6 +15,13 @@ const CaseDetail = () => {
   const { caseId } = useParams();
 
   const caseStudy = useMemo(() => cases.find((item) => item.slug === caseId), [caseId]);
+  const relatedArticle = useMemo(
+    () =>
+      caseStudy?.relatedBlogSlug
+        ? blogPosts.find((post) => post.slug === caseStudy.relatedBlogSlug)
+        : undefined,
+    [caseStudy?.relatedBlogSlug]
+  );
 
   const seoTitle = caseStudy ? `${caseStudy.title} — Caso de éxito CapassoTech` : "Caso de éxito — CapassoTech";
   const seoDescription = caseStudy
@@ -58,6 +66,14 @@ const CaseDetail = () => {
               <p className="text-sm uppercase tracking-wide text-capasso-primary/70">{caseStudy.category}</p>
               <h1 className="mt-3 text-4xl font-bold text-white md:text-5xl">{caseStudy.title}</h1>
               <p className="mt-4 text-lg text-capasso-light/80">{caseStudy.description}</p>
+              {relatedArticle && (
+                <div className="mt-6 flex flex-wrap items-center gap-3 text-sm text-capasso-light/70">
+                  <span>Profundizá en la historia completa:</span>
+                  <Button asChild className="btn-secondary px-5 py-2 text-sm">
+                    <Link to={`/blog/${relatedArticle.slug}`}>Leer artículo del blog</Link>
+                  </Button>
+                </div>
+              )}
               <div className="mt-6 flex flex-wrap gap-3 text-sm text-capasso-light/60">
                 <span className="rounded-full border border-capasso-primary/30 bg-capasso-secondary/60 px-4 py-2">{caseStudy.duration}</span>
                 {caseStudy.services?.map((service) => (
@@ -119,6 +135,17 @@ const CaseDetail = () => {
                   ))}
                 </div>
               </div>
+              {relatedArticle && (
+                <div className="rounded-2xl border border-capasso-primary/20 bg-capasso-primary/10 p-6">
+                  <h3 className="text-lg font-semibold text-white">Leé el análisis completo</h3>
+                  <p className="mt-3 text-sm text-capasso-light/80">
+                    Detallamos este proyecto en nuestro blog con métricas, aprendizajes y próximos pasos.
+                  </p>
+                  <Button asChild className="btn-secondary mt-4 w-full">
+                    <Link to={`/blog/${relatedArticle.slug}`}>Ir al artículo</Link>
+                  </Button>
+                </div>
+              )}
               <div className="rounded-2xl border border-capasso-primary/20 bg-capasso-primary/10 p-6">
                 <h3 className="text-lg font-semibold text-white">¿Caso parecido al tuyo?</h3>
                 <p className="mt-3 text-sm text-capasso-light/80">

--- a/src/pages/Cases.jsx
+++ b/src/pages/Cases.jsx
@@ -40,6 +40,15 @@ const casesStructuredData = cases.map((caseStudy) => ({
     "@type": "Thing",
     name: tech,
   })),
+  ...(caseStudy.relatedBlogSlug
+    ? {
+        sameAs: [`https://capassotech.com/blog/${caseStudy.relatedBlogSlug}`],
+        subjectOf: {
+          "@type": "BlogPosting",
+          url: `https://capassotech.com/blog/${caseStudy.relatedBlogSlug}`,
+        },
+      }
+    : {}),
   hasPart: [
     {
       "@type": "CreativeWork",
@@ -122,23 +131,33 @@ const Cases = () => {
                       </span>
                     )}
                   </div>
-                  <ul className="mt-6 space-y-2 text-sm text-capasso-light/80">
-                    {caseStudy.results.slice(0, 3).map((result) => (
-                      <li key={result} className="flex items-start gap-3">
-                        <span className="mt-1 inline-block h-2 w-2 rounded-full bg-capasso-primary" />
-                        <span>{result}</span>
-                      </li>
-                    ))}
-                  </ul>
-                  <div className="mt-8 flex-1" />
+              <ul className="mt-6 space-y-2 text-sm text-capasso-light/80">
+                {caseStudy.results.slice(0, 3).map((result) => (
+                  <li key={result} className="flex items-start gap-3">
+                    <span className="mt-1 inline-block h-2 w-2 rounded-full bg-capasso-primary" />
+                    <span>{result}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-8 flex-1" />
+              <div className="mt-6 flex flex-wrap items-center gap-4 text-sm">
+                <Link
+                  to={`/casos/${caseStudy.slug}`}
+                  className="inline-flex items-center text-capasso-primary transition-colors hover:text-white"
+                >
+                  Ver caso →
+                </Link>
+                {caseStudy.relatedBlogSlug && (
                   <Link
-                    to={`/casos/${caseStudy.slug}`}
-                    className="mt-6 inline-flex items-center text-capasso-primary transition-colors hover:text-white"
+                    to={`/blog/${caseStudy.relatedBlogSlug}`}
+                    className="inline-flex items-center text-capasso-light/70 transition-colors hover:text-capasso-primary"
                   >
-                    Ver detalle →
+                    Leer artículo →
                   </Link>
-                </article>
-              ))}
+                )}
+              </div>
+            </article>
+          ))}
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add metadata to cases and blog posts so success stories reference their related articles
- surface "ver caso" and "leer artículo" actions across case study cards, detail pages, and blog listings
- enrich structured data and blog post layout with case study cross-links for better SEO context

## Testing
- npm run lint
- npm run build *(fails: tsx command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4448d3f008330b69f267d037d0798